### PR TITLE
Add GitHub action for building and testing with multiple versions of Go

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,8 +24,8 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
 
-    - name: Build
+    - name: Build Go ${{ matrix.go }}
       run: go build -v ./...
 
-    - name: Test
+    - name: Test Go ${{ matrix.go }}
       run: go test -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,31 @@
+# This workflow will build and test a golang project for multiple versions of Go
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.18', '1.19', '1.20', '1.21', '>=1.22' ]
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go ${{ matrix.go }}
+      uses: actions/setup-go@v4
+      with:
+        go-version: ${{ matrix.go }}
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...


### PR DESCRIPTION
This change adds the basic implementation of a GitHub action to trigger a matrix build of various Go versions, from 1.18 and up, including running tests.