### PR TITLE
Restrict workflow permissions to read-only

### DIFF
--- a/.github/workflows/go-build-matrix.yml
+++ b/.github/workflows/go-build-matrix.yml
@@ -3,6 +3,10 @@
 
 name: Go
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   push:
     branches: ["master"]


### PR DESCRIPTION
This tries to fix https://github.com/rcdmk/go-ratelimiter/security/code-scanning/1 by setting permissions on the workflow to read-only.